### PR TITLE
feat: accept random instance in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 
 * Added possibility to call RandomNames with a random zone (with no parameters)
 * Improved examples and documentation
+
+## 1.4.0 - 29 Aug 2024
+
+* Added possibility to pass a `Random` instance to `RandomNames` constructor.

--- a/lib/src/random_name_generator_base.dart
+++ b/lib/src/random_name_generator_base.dart
@@ -1,36 +1,41 @@
+import 'dart:math';
+
 import 'zone.dart';
 
 /// Base class for random name generators
 class RandomNames {
-  late Zone _zone;
+  final Zone _zone;
+  final Random? _random;
 
-  RandomNames([Zone? zone]) {
-    if (zone == null) {
-      Zone.all.shuffle();
-      _zone = Zone.all.first;
-    } else {
-      _zone = zone;
-    }
-  }
+  /// Creates a new instance of RandomNames that accepts a [Random] instance
+  /// to be used for generating random names allowing to generate names in a
+  /// reproducible way.
+  RandomNames.seeded({
+    Zone? zone,
+    Random? random,
+  })  : _random = random,
+        _zone = zone ?? ([...Zone.all]..shuffle(random)).first;
+
+  factory RandomNames([Zone? zone]) => RandomNames.seeded(zone: zone);
 
   /// Returns a random first name
   String name() {
-    return (_zone.names..shuffle()).first;
+    return ([..._zone.names]..shuffle(_random)).first;
   }
 
   /// Returns a random first name for a woman
   String womanName() {
-    return (_zone.namesW..shuffle()).first;
+    return ([..._zone.namesW]..shuffle(_random)).first;
   }
 
   /// Returns a random first name for a man
   String manName() {
-    return (_zone.namesM..shuffle()).first;
+    return ([..._zone.namesM]..shuffle(_random)).first;
   }
 
   /// Returns a random surname
   String surname() {
-    return (_zone.surnames..shuffle()).first;
+    return ([..._zone.surnames]..shuffle(_random)).first;
   }
 
   /// Returns a random full name

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: random_name_generator
 description: Dart package for the generation of Random Names, based on most common names
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/poqueque/random_name_generator
 
 environment:

--- a/test/random_name_generator_test.dart
+++ b/test/random_name_generator_test.dart
@@ -1,8 +1,10 @@
+import 'dart:math';
+
 import 'package:random_name_generator/random_name_generator.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('A group of tests', () {
+  group('RandomNames', () {
     final randomNames = RandomNames(Zone.us);
 
     setUp(() {
@@ -12,6 +14,21 @@ void main() {
     test('First Test', () {
       expect(randomNames.fullName().length, greaterThanOrEqualTo(7));
       expect(randomNames.fullName(), contains(" "));
+    });
+
+    test(
+        '.seeded allows to generate the same names using the same Random '
+        'instance', () {
+      final rnd1 = RandomNames.seeded(random: Random(42));
+      final rnd2 = RandomNames.seeded(random: Random(42));
+
+      expect(rnd1.name(), rnd2.name());
+      expect(rnd1.surname(), rnd2.surname());
+      expect(rnd1.fullName(), rnd2.fullName());
+      expect(rnd1.womanFullName(), rnd2.womanFullName());
+      expect(rnd1.manFullName(), rnd2.manFullName());
+      expect(rnd1.manName(), rnd2.manName());
+      expect(rnd1.womanName(), rnd2.womanName());
     });
   });
 }


### PR DESCRIPTION
Also I have changed the shuffle behavior: instead of shuffling the original static member `zones` it shuffles a copy of the list, without changing the original one. I used a similar approach also for the methods `name` etc.